### PR TITLE
Enable agent file creation and fix test execution

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,7 +32,9 @@ AVAILABLE_MODELS = {
 # Настройки агентов
 MAX_ITERATIONS = int(os.getenv('MAX_ITERATIONS', '10'))  # Максимальное количество циклов
 AGENT_TIMEOUT = int(os.getenv('AGENT_TIMEOUT', '180'))  # Таймаут для каждого агента в секундах (увеличен с 60 до 180)
-CREATE_FILES_DURING_AGENTS = os.getenv('CREATE_FILES_DURING_AGENTS', 'false').lower() == 'true'
+# По умолчанию разрешаем агентам создавать файлы, чтобы проект был
+# сформирован даже без указания переменной окружения.
+CREATE_FILES_DURING_AGENTS = os.getenv('CREATE_FILES_DURING_AGENTS', 'true').lower() == 'true'
 MIN_SUCCESS_ITERATIONS = int(os.getenv('MIN_SUCCESS_ITERATIONS', '2'))  # Минимум итераций до возможности завершить
 AGENT_RETRIES = int(os.getenv('AGENT_RETRIES', '3'))  # Повторы задачи агента при сбое (увеличен с 1 до 3)
 SUCCESS_THRESHOLD = float(os.getenv('SUCCESS_THRESHOLD', '0.7'))  # Порог успешности агентов (70%)

--- a/test_file_fix.py
+++ b/test_file_fix.py
@@ -4,9 +4,10 @@
 """
 import asyncio
 import logging.config
+from pathlib import Path
+
 from config import LOGGING_CONFIG, AGENT_ROLES
 from agents import BaseAgent
-from pathlib import Path
 from rich.console import Console
 
 # Настраиваем логирование
@@ -15,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 console = Console()
 
-async def test_devops_files():
+
+def test_devops_files():
     """Тестирует создание DevOps файлов с правильными именами"""
     
     console.print("[bold blue]🧪 ТЕСТ ИСПРАВЛЕННОЙ ЛОГИКИ ФАЙЛОВ[/bold blue]")
@@ -93,7 +95,9 @@ jobs:
         
         # Тестируем функцию создания файлов
         context = {"project_name": "FileFixTest"}
-        files_created = await devops_agent._create_files_from_response(devops_response, context)
+        files_created = asyncio.run(
+            devops_agent._create_files_from_response(devops_response, context)
+        )
         
         console.print(f"\n[green]✅ РЕЗУЛЬТАТЫ:[/green]")
         console.print(f"[white]Создано файлов: {len(files_created)}[/white]")
@@ -119,4 +123,4 @@ jobs:
         logger.error(f"Ошибка теста: {e}", exc_info=True)
 
 if __name__ == "__main__":
-    asyncio.run(test_devops_files())
+    test_devops_files()


### PR DESCRIPTION
## Summary
- allow agents to write files by default via `CREATE_FILES_DURING_AGENTS`
- convert devops file creation test to synchronous execution for pytest

## Testing
- `pytest -q`
- `python test_file_fix.py`


------
https://chatgpt.com/codex/tasks/task_b_68b4492de6608328aeece38b7521a812